### PR TITLE
Fix permission_handler configuration in Podfile

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,9 +37,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
-  end
-
-  # Start of the permission_handler configuration
+    
+    # Start of the permission_handler configuration
     target.build_configurations.each do |config|
    
       # You can enable the permissions needed here. For example to enable camera
@@ -97,4 +96,6 @@ post_install do |installer|
   
     end 
     # End of the permission_handler configuration
+  
+  end
 end


### PR DESCRIPTION
The `permission_handler` configuration uses `target` variable, but the config was added outside of targets iterator block, thus `pod install` was failing